### PR TITLE
Don't define _GNU_SOURCE

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,3 @@
-#define _GNU_SOURCE
-
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
Defining _GNU_SOURCE does not seem necessary with
newer versions of gcc and does, in fact, cause the compiler gcc 10.2 to warn about "_GNU_SOURCE" begin redefined.